### PR TITLE
Adds webfinger setup for mastodon gods

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -32,6 +32,7 @@ module.exports = function (conf) {
   conf.addPassthroughCopy("./src/manifest.webmanifest");
   conf.addPassthroughCopy("./src/keybase.txt");
   conf.addPassthroughCopy("./src/rss.xml");
+  conf.addPassthroughCopy("./src/.well-known");
 
   conf.addWatchTarget("./src/**/*.css");
 

--- a/src/.well-known/webfinger
+++ b/src/.well-known/webfinger
@@ -1,0 +1,23 @@
+{
+  "subject": "acct:tylergaw@mastodon.social",
+  "aliases": [
+    "https://mastodon.social/@tylergaw",
+    "https://mastodon.social/users/tylergaw"
+  ],
+  "links": [
+    {
+      "rel": "http://webfinger.net/rel/profile-page",
+      "type": "text/html",
+      "href": "https://mastodon.social/@tylergaw"
+    },
+    {
+      "rel": "self",
+      "type": "application/activity+json",
+      "href": "https://mastodon.social/users/tylergaw"
+    },
+    {
+      "rel": "http://ostatus.org/schema/1.0/subscribe",
+      "template": "https://mastodon.social/authorize_interaction?uri={uri}"
+    }
+  ]
+}


### PR DESCRIPTION
Like a lot folks, I'm giving Mastodon a more serious try. Matt shared something cool he found here https://mastodon.social/@MattHodges/109394246861547186 I'm doing the same thing.

This will allow people in the fediverse (cringe name) to find any of my Mastodon profiles with a search for `<anything>@tylergaw.com`. I followed the instructions in the blog post by Maarten https://blog.maartenballiauw.be/post/2022/11/05/mastodon-own-donain-without-hosting-server.html that Matt linked to.

**Difference for 11ty**
This site is built with eleventy. To make sure the `.well-known` directory is copied to the build directory, I added a `addPassthroughCopy` entry for it. See https://www.11ty.dev/docs/copy/

**Changes**
* Adds a .well-known directory with webfinger conf
* Adds a passthrough for the .well-known directory